### PR TITLE
Feature: add remarks to the generated ss link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Simply copy and paste the following in a terminal:
 python <(curl -s https://raw.githubusercontent.com/amayatsky/shadowsocks-url-generator/master/ss-genuri.py) \
 -c /etc/shadowsocks-libev/config.json
 ```
-Change /etc/shadowsocks-libev/config.json path if needed.
+Change `/etc/shadowsocks-libev/config.json` path if needed. Alternatively, you can provide a different config file path
 
 ### Example
 Input:
-```javascript
+```json
 {
+    "remarks": "ShadowSocks Server",
     "server":"github.com",
     "server_port":8388,
     "password":"fake_pwd",
@@ -20,8 +21,8 @@ Input:
 }
 ```
 Output:
-```bash
-ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpmYWtlX3B3ZEBnaXRodWIuY29tOjgzODg=
+```
+ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpmYWtlX3B3ZEBnaXRodWIuY29tOjgzODg=#ShadowSocksServer
 ```
 
 ### Requirements

--- a/ss-genuri.py
+++ b/ss-genuri.py
@@ -6,12 +6,14 @@ import base64
 parser = argparse.ArgumentParser(description='A script that parses Shadowsocks server configuration file and generates '
                                              'a client configuration URI')
 parser.add_argument('--config', '-c', type=str, help='A path to your Shadowsocks server config.json')
+
 args = parser.parse_args()
+
 if args.config is None:
     args.config='/etc/shadowsocks-libev/config.json'
     print('Using default config path: {}'.format(args.config))
 
-config = json.load(open(args.config))
+config = json.load(open(args.config, 'r'))
 
 uri = "%s:%s@%s:%d" % (
     config['method'],
@@ -20,5 +22,12 @@ uri = "%s:%s@%s:%d" % (
     config['server_port'],
 )
 
-encoded_uri = base64.b64encode(uri.encode('utf-8'))
-print('ss://%s' % encoded_uri.decode('utf-8'))
+encoded_uri = base64.b64encode(uri.encode('utf-8')).decode('utf-8')
+
+remarks = 'Shadowsocks Server'
+
+if 'remarks' in config: remarks = config['remarks']
+
+remarks = "".join(remarks.split(' '))
+
+print(f"ss://{encoded_uri}#{remarks}")

--- a/ss-genuri.py
+++ b/ss-genuri.py
@@ -24,10 +24,6 @@ uri = "%s:%s@%s:%d" % (
 
 encoded_uri = base64.b64encode(uri.encode('utf-8')).decode('utf-8')
 
-remarks = 'Shadowsocks Server'
-
-if 'remarks' in config: remarks = config['remarks']
-
+remarks = config.get('remarks', 'Shadowsocks Server')
 remarks = "".join(remarks.split(' '))
-
-print(f"ss://{encoded_uri}#{remarks}")
+print('ss://%s%s' % (encoded_uri, remarks))

--- a/ss-genuri.py
+++ b/ss-genuri.py
@@ -26,4 +26,4 @@ encoded_uri = base64.b64encode(uri.encode('utf-8')).decode('utf-8')
 
 remarks = config.get('remarks', 'Shadowsocks Server')
 remarks = "".join(remarks.split(' '))
-print('ss://%s%s' % (encoded_uri, remarks))
+print('ss://%s#%s' % (encoded_uri, remarks))


### PR DESCRIPTION
@amayatsky thank you for this handy tool.

`config.json` for Shadowsocks also includes a value called "remarks" which is basically the alias or the name for that configuration/server. it becomes very useful when working with multiple clients/servers. I've modified the code to add `remarks` at the end of the final `ss://` link. 